### PR TITLE
Add edit and editencounter command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -332,6 +332,70 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
+**Use case: Edit a person**
+
+**MSS**
+
+1.  User requests to list persons
+2.  CrimeWatch shows a list of contacts
+3.  User requests to edit a specific person in the list with one or more fields
+4.  CrimeWatch updates only the provided fields for that contact
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. The list is empty.
+
+  Use case ends.
+
+* 3a. The given index is invalid.
+
+    * 3a1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
+* 3b. No editable field is provided.
+
+    * 3b1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
+**Use case: Edit an encounter**
+
+**MSS**
+
+1.  User requests to view a contact profile
+2.  CrimeWatch shows encounter cards with encounter indices
+3.  User requests to edit a specific encounter using `PERSON_INDEX` and `ENCOUNTER_INDEX`
+4.  CrimeWatch updates only the provided encounter fields
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. The contact has no encounters.
+
+  Use case ends.
+
+* 3a. The given person index is invalid.
+
+    * 3a1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
+* 3b. The given encounter index is invalid.
+
+    * 3b1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
+* 3c. No editable field is provided.
+
+    * 3c1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
 *{More to be added}*
 
 ### Non-Functional Requirements

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -6,13 +6,27 @@ title: User Guide
 This guide is intended for users who prefer fast, keyboard-driven workflows. You should be comfortable with basic computer operations such as installing software and using a command terminal. No programming experience is required.
 
 ## What is CrimeWatch?
-CrimeWatch is a CLI-based contact tracking tool for managing **person-of-interest profiles** and their **encounter logs**. The MVP supports exactly these five features:
+CrimeWatch is a CLI-based contact tracking tool for managing **person-of-interest profiles** and their **encounter logs**. It supports the following features:
 
 1. Add Contact
-2. Delete Contact
-3. Log Encounter
-4. View Contact
-5. Search Contacts
+2. Edit Contact
+3. Delete Contact
+4. Log Encounter
+5. Edit Encounter
+6. View Contact
+7. Search Contacts
+
+## Command summary
+
+| Feature | Command format |
+| --- | --- |
+| Add Contact | `add n/NAME a/ALIAS s/STAGE [r/RISK] [note/NOTES]` |
+| Edit Contact | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STAGE] [al/ALIAS(,ALIAS...)] [note/NOTES] [r/RISK] [t/TAG]...` |
+| Delete Contact | `delete INDEX` |
+| Log Encounter | `log INDEX d/DATE t/TIME l/LOCATION desc/DESCRIPTION [out/OUTCOME]` |
+| Edit Encounter | `editencounter PERSON_INDEX ENCOUNTER_INDEX [d/DATE] [t/TIME] [l/LOCATION] [desc/DESCRIPTION] [out/OUTCOME]` |
+| View Contact | `view INDEX` |
+| Search Contacts | `find KEYWORD [MORE_KEYWORDS]` |
    
 * Table of Contents
 {:toc}
@@ -59,8 +73,9 @@ CrimeWatch is a CLI-based contact tracking tool for managing **person-of-interes
 - Parameters can be in any order unless stated otherwise.
 - Optional parameters are shown in square brackets `[LIKE_THIS]`.
 - **Do not repeat prefixes** in the same command (e.g. `n/... n/...`) — this is treated as an error.
-- Index-based commands (`view`, `log`, `delete`) use the **INDEX shown in the current contact list panel**.
+- Index-based commands (`view`, `log`, `delete`, `edit`) use the **INDEX shown in the current contact list panel**.
   - INDEX must be a positive integer: `1, 2, 3, ...`
+- For `editencounter`, use two indices: `PERSON_INDEX` from contact list and `ENCOUNTER_INDEX` from the viewed encounter cards.
  
 --------------------------------------------------------------------------------------------------------------------
 
@@ -157,7 +172,33 @@ Error message:
 
 --------------------------------------------------------------------------------------------------------------------
 
-### 2) Delete Contact: `delete`
+### 2) Edit Contact: `edit`
+
+Updates details of an existing contact without deleting and re-adding the profile.
+
+**Format**
+`edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STAGE] [al/ALIAS(,ALIAS...)] [note/NOTES] [r/RISK] [t/TAG]...`
+
+**Parameters**
+- `INDEX` (compulsory): target contact in current list
+- At least one prefixed field must be provided
+- Any omitted field remains unchanged
+
+**Examples**
+- `edit 1 p/91234567 e/johndoe@example.com`
+- `edit 2 r/high note/More cooperative in latest meeting`
+
+**Validation**
+- INDEX must exist in the current list.
+- Provided fields follow the same validation rules as `add`.
+- Repeating non-tag prefixes in the same command is not allowed.
+
+**Success output**
+`Edited Person: [person details]`
+
+--------------------------------------------------------------------------------------------------------------------
+
+### 3) Delete Contact: `delete`
 
 Removes a contact **and all associated encounters** permanently.
 
@@ -176,7 +217,7 @@ Removes a contact **and all associated encounters** permanently.
 
 --------------------------------------------------------------------------------------------------------------------
 
-### 3) Log Encounter: `log`
+### 4) Log Encounter: `log`
 
 Records an interaction with a contact and appends it to the contact’s encounter history.
 
@@ -205,7 +246,38 @@ Records an interaction with a contact and appends it to the contact’s encounte
 
 --------------------------------------------------------------------------------------------------------------------
 
-### 4) View Contact: `view`
+### 5) Edit Encounter: `editencounter`
+
+Updates an existing encounter for a contact.
+
+**Format**
+`editencounter PERSON_INDEX ENCOUNTER_INDEX [d/DATE] [t/TIME] [l/LOCATION] [desc/DESCRIPTION] [out/OUTCOME]`
+
+**Parameters**
+- `PERSON_INDEX` (compulsory): target contact in current list
+- `ENCOUNTER_INDEX` (compulsory): target encounter from the viewed encounter cards
+- At least one prefixed field must be provided
+
+**Encounter index mapping**
+- Encounter cards shown in `view` are numbered newest first.
+- `ENCOUNTER_INDEX 1` means the most recent encounter shown as `#1`.
+
+**Examples**
+- `editencounter 1 1 desc/Updated observation notes`
+- `editencounter 1 2 d/2026-03-27 t/20:15 l/Tanjong Pagar out/`
+
+**Validation**
+- PERSON_INDEX must exist in the current contact list.
+- ENCOUNTER_INDEX must exist for that contact.
+- Provided fields use the same validation rules as `log`.
+- `out/` with an empty value clears outcome.
+
+**Success output**
+`Edited encounter #[ENCOUNTER_INDEX] for [Name].`
+
+--------------------------------------------------------------------------------------------------------------------
+
+### 6) View Contact: `view`
 
 Displays the full profile of a contact and their chronological encounter history.
 
@@ -222,7 +294,7 @@ Displays the full profile of a contact and their chronological encounter history
 
 --------------------------------------------------------------------------------------------------------------------
 
-### 5) Search Contacts: `find`
+### 7) Search Contacts: `find`
 
 Retrieves contacts by keyword across multiple fields.
 
@@ -287,12 +359,14 @@ _Details coming soon ..._
 
 --------------------------------------------------------------------------------------------------------------------
 
-## Command summary (MVP)
+## Command summary
 
 Action | Format | Example
 ---|---|---
 Add Contact | `add n/NAME a/ALIAS s/STAGE [r/RISK] [note/NOTES]` | `add n/John Tan a/Ah Boy s/surveillance`
+Edit Contact | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STAGE] [al/ALIAS(,ALIAS...)] [note/NOTES] [r/RISK] [t/TAG]...` | `edit 1 p/91234567 r/high`
 Delete Contact | `delete INDEX` | `delete 3`
 Log Encounter | `log INDEX d/DATE t/TIME l/LOCATION desc/DESCRIPTION [out/OUTCOME]` | `log 1 d/2026-02-21 t/18:30 l/Maxwell Road desc/Met...`
+Edit Encounter | `editencounter PERSON_INDEX ENCOUNTER_INDEX [d/DATE] [t/TIME] [l/LOCATION] [desc/DESCRIPTION] [out/OUTCOME]` | `editencounter 1 1 desc/Updated notes`
 View Contact | `view INDEX` | `view 1`
 Search Contacts | `find KEYWORD [MORE_KEYWORDS]` | `find mike marina`

--- a/src/main/java/seedu/address/logic/commands/EditEncounterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEncounterCommand.java
@@ -1,0 +1,248 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OUTCOME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Encounter;
+import seedu.address.model.person.Person;
+
+/**
+ * Edits an existing encounter for a contact in CrimeWatch.
+ */
+public class EditEncounterCommand extends Command {
+
+    public static final String COMMAND_WORD = "editencounter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the details of an encounter identified by person index and encounter index.\n"
+            + "Parameters: PERSON_INDEX ENCOUNTER_INDEX "
+            + "[" + PREFIX_DATE + "DATE] "
+            + "[" + PREFIX_TIME + "TIME] "
+            + "[" + PREFIX_LOCATION + "LOCATION] "
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_OUTCOME + "OUTCOME]\n"
+            + "Example: " + COMMAND_WORD + " 1 2 "
+            + PREFIX_LOCATION + "Maxwell Road "
+            + PREFIX_DESCRIPTION + "Met at coffee shop";
+
+    public static final String MESSAGE_SUCCESS = "Edited encounter #%1$d for %2$s.";
+    public static final String MESSAGE_INVALID_ENCOUNTER_DISPLAYED_INDEX =
+            "The encounter index provided is invalid.";
+    public static final String MESSAGE_NOT_EDITED = "At least one encounter field to edit must be provided.";
+
+    private final Index personIndex;
+    private final Index encounterIndex;
+    private final EditEncounterDescriptor editEncounterDescriptor;
+
+    /**
+     * @param personIndex of the person in the filtered person list
+     * @param encounterIndex display index of encounter shown in view panel (#1 is most recent)
+     * @param editEncounterDescriptor encounter fields to edit
+     */
+    public EditEncounterCommand(
+            Index personIndex,
+            Index encounterIndex,
+            EditEncounterDescriptor editEncounterDescriptor) {
+        requireNonNull(personIndex);
+        requireNonNull(encounterIndex);
+        requireNonNull(editEncounterDescriptor);
+        this.personIndex = personIndex;
+        this.encounterIndex = encounterIndex;
+        this.editEncounterDescriptor = new EditEncounterDescriptor(editEncounterDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (personIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(personIndex.getZeroBased());
+        List<Encounter> existingEncounters = personToEdit.getEncounters();
+        int encounterDisplayOneBased = encounterIndex.getOneBased();
+        if (encounterDisplayOneBased > existingEncounters.size()) {
+            throw new CommandException(MESSAGE_INVALID_ENCOUNTER_DISPLAYED_INDEX);
+        }
+
+        // Encounter cards are shown in reverse-chronological order where #1 is the most recent.
+        int encounterZeroBased = existingEncounters.size() - encounterDisplayOneBased;
+        Encounter encounterToEdit = existingEncounters.get(encounterZeroBased);
+        Encounter editedEncounter = createEditedEncounter(encounterToEdit, editEncounterDescriptor);
+
+        List<Encounter> updatedEncounters = new ArrayList<>(existingEncounters);
+        updatedEncounters.set(encounterZeroBased, editedEncounter);
+
+        Person editedPerson = new Person(
+                personToEdit.getName(),
+                personToEdit.getPhone(),
+                personToEdit.getEmail(),
+                personToEdit.getAddress(),
+                personToEdit.getStage(),
+                personToEdit.getAliases(),
+                personToEdit.getNotes(),
+                personToEdit.getRisk(),
+                personToEdit.getTags(),
+                updatedEncounters);
+
+        model.setPerson(personToEdit, editedPerson);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, encounterDisplayOneBased, personToEdit.getName()));
+    }
+
+    private static Encounter createEditedEncounter(Encounter encounterToEdit, EditEncounterDescriptor descriptor) {
+        LocalDate date = descriptor.getDate().orElse(encounterToEdit.dateTime.toLocalDate());
+        LocalTime time = descriptor.getTime().orElse(encounterToEdit.dateTime.toLocalTime());
+        LocalDateTime updatedDateTime = LocalDateTime.of(date, time);
+        String updatedLocation = descriptor.getLocation().orElse(encounterToEdit.location);
+        String updatedDescription = descriptor.getDescription().orElse(encounterToEdit.description);
+        Optional<String> updatedOutcome = descriptor.getOutcome().orElse(encounterToEdit.outcome);
+
+        return new Encounter(updatedDateTime, updatedLocation, updatedDescription, updatedOutcome);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof EditEncounterCommand)) {
+            return false;
+        }
+        EditEncounterCommand otherCommand = (EditEncounterCommand) other;
+        return personIndex.equals(otherCommand.personIndex)
+                && encounterIndex.equals(otherCommand.encounterIndex)
+                && editEncounterDescriptor.equals(otherCommand.editEncounterDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("personIndex", personIndex)
+                .add("encounterIndex", encounterIndex)
+                .add("editEncounterDescriptor", editEncounterDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the encounter with.
+     */
+    public static class EditEncounterDescriptor {
+        private LocalDate date;
+        private LocalTime time;
+        private String location;
+        private String description;
+        private Optional<String> outcome;
+
+        public EditEncounterDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditEncounterDescriptor(EditEncounterDescriptor toCopy) {
+            setDate(toCopy.date);
+            setTime(toCopy.time);
+            setLocation(toCopy.location);
+            setDescription(toCopy.description);
+            setOutcome(toCopy.outcome);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(date, time, location, description, outcome);
+        }
+
+        public void setDate(LocalDate date) {
+            this.date = date;
+        }
+
+        public Optional<LocalDate> getDate() {
+            return Optional.ofNullable(date);
+        }
+
+        public void setTime(LocalTime time) {
+            this.time = time;
+        }
+
+        public Optional<LocalTime> getTime() {
+            return Optional.ofNullable(time);
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        public Optional<String> getLocation() {
+            return Optional.ofNullable(location);
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public Optional<String> getDescription() {
+            return Optional.ofNullable(description);
+        }
+
+        /**
+         * Sets outcome to this descriptor. Use Optional.empty() to clear outcome.
+         */
+        public void setOutcome(Optional<String> outcome) {
+            this.outcome = (outcome != null) ? Optional.ofNullable(outcome.orElse(null)) : null;
+        }
+
+        /**
+         * Returns optional outcome wrapped in Optional, or empty if not edited.
+         */
+        public Optional<Optional<String>> getOutcome() {
+            return Optional.ofNullable(outcome);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+            if (!(other instanceof EditEncounterDescriptor)) {
+                return false;
+            }
+            EditEncounterDescriptor otherDescriptor = (EditEncounterDescriptor) other;
+            return Objects.equals(date, otherDescriptor.date)
+                    && Objects.equals(time, otherDescriptor.time)
+                    && Objects.equals(location, otherDescriptor.location)
+                    && Objects.equals(description, otherDescriptor.description)
+                    && Objects.equals(outcome, otherDescriptor.outcome);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("date", date)
+                    .add("time", time)
+                    .add("location", location)
+                    .add("description", description)
+                    .add("outcome", outcome)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditEncounterCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -60,6 +61,9 @@ public class AddressBookParser {
 
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
+
+        case EditEncounterCommand.COMMAND_WORD:
+            return new EditEncounterCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditEncounterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEncounterCommandParser.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OUTCOME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditEncounterCommand;
+import seedu.address.logic.commands.EditEncounterCommand.EditEncounterDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditEncounterCommand object.
+ */
+public class EditEncounterCommandParser implements Parser<EditEncounterCommand> {
+
+    @Override
+    public EditEncounterCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_TIME, PREFIX_LOCATION, PREFIX_DESCRIPTION,
+                        PREFIX_OUTCOME);
+
+        String preamble = argMultimap.getPreamble().trim();
+        String[] parts = preamble.split("\\s+");
+        if (parts.length != 2) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+        }
+
+        Index personIndex;
+        Index encounterIndex;
+        try {
+            personIndex = ParserUtil.parseIndex(parts[0]);
+            encounterIndex = ParserUtil.parseIndex(parts[1]);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_TIME, PREFIX_LOCATION, PREFIX_DESCRIPTION,
+                PREFIX_OUTCOME);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            descriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TIME).isPresent()) {
+            descriptor.setTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
+            descriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+            descriptor.setDescription(
+                    ParserUtil.parseEncounterDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
+        }
+        if (argMultimap.getValue(PREFIX_OUTCOME).isPresent()) {
+            String outcome = ParserUtil.parseOutcome(argMultimap.getValue(PREFIX_OUTCOME).get());
+            descriptor.setOutcome(outcome.isEmpty() ? Optional.empty() : Optional.of(outcome));
+        }
+
+        if (!descriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditEncounterCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditEncounterCommand(personIndex, encounterIndex, descriptor);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -14,6 +14,9 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -23,6 +26,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Encounter;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -143,6 +147,35 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_editFieldsSpecified_preservesEncounters() {
+        Encounter existingEncounter = new Encounter(
+                LocalDateTime.of(2026, 3, 10, 9, 30),
+                "Maxwell Road",
+                "Observed handoff",
+                Optional.of("Follow-up required"));
+        Person personWithEncounter = new PersonBuilder(
+                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withEncounters(existingEncounter)
+                .build();
+        model.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), personWithEncounter);
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withRisk(VALID_RISK_HIGH).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        Person expectedEditedPerson = new PersonBuilder(personWithEncounter).withRisk(VALID_RISK_HIGH).build();
+        String expectedMessage =
+                String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(expectedEditedPerson));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(personWithEncounter, expectedEditedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertEquals(1, model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getEncounters().size());
+        assertEquals(existingEncounter, model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())
+                .getEncounters().get(0));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditEncounterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEncounterCommandTest.java
@@ -1,0 +1,221 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditEncounterCommand.EditEncounterDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Encounter;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditEncounterCommand.
+ */
+public class EditEncounterCommandTest {
+
+    private static final Encounter OLDER_ENCOUNTER = new Encounter(
+            LocalDateTime.of(2026, 3, 20, 10, 30),
+            "Chinatown",
+            "Brief interaction",
+            Optional.of("Observed"));
+
+    private static final Encounter NEWER_ENCOUNTER = new Encounter(
+            LocalDateTime.of(2026, 3, 25, 19, 15),
+            "Marina Bay",
+            "Long discussion",
+            Optional.of("Pending"));
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexesAndFields_success() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER, NEWER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setLocation("Maxwell Road");
+        descriptor.setDescription("Met at coffee shop");
+        descriptor.setOutcome(Optional.of("Agreed to follow up"));
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        Encounter editedNewer = new Encounter(
+                LocalDateTime.of(2026, 3, 25, 19, 15),
+                "Maxwell Road",
+                "Met at coffee shop",
+                Optional.of("Agreed to follow up"));
+
+        Person expectedEditedPerson = new PersonBuilder(withEncounters)
+                .withEncounters(OLDER_ENCOUNTER, editedNewer)
+                .build();
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(withEncounters, expectedEditedPerson);
+
+        String expectedMessage = String.format(EditEncounterCommand.MESSAGE_SUCCESS, 1, withEncounters.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_clearOutcome_success() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setOutcome(Optional.empty());
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        Encounter edited = new Encounter(
+                LocalDateTime.of(2026, 3, 20, 10, 30),
+                "Chinatown",
+                "Brief interaction",
+                Optional.empty());
+
+        Person expectedEditedPerson = new PersonBuilder(withEncounters).withEncounters(edited).build();
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(withEncounters, expectedEditedPerson);
+
+        String expectedMessage = String.format(EditEncounterCommand.MESSAGE_SUCCESS, 1, withEncounters.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editDateOnly_preservesTime() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDate(LocalDate.of(2026, 4, 1));
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        Encounter edited = new Encounter(
+                LocalDateTime.of(2026, 4, 1, 10, 30),
+                "Chinatown",
+                "Brief interaction",
+                Optional.of("Observed"));
+
+        Person expectedEditedPerson = new PersonBuilder(withEncounters).withEncounters(edited).build();
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(withEncounters, expectedEditedPerson);
+
+        String expectedMessage = String.format(EditEncounterCommand.MESSAGE_SUCCESS, 1, withEncounters.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_editTimeOnly_preservesDate() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setTime(LocalTime.of(11, 45));
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        Encounter edited = new Encounter(
+                LocalDateTime.of(2026, 3, 20, 11, 45),
+                "Chinatown",
+                "Brief interaction",
+                Optional.of("Observed"));
+
+        Person expectedEditedPerson = new PersonBuilder(withEncounters).withEncounters(edited).build();
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(withEncounters, expectedEditedPerson);
+
+        String expectedMessage = String.format(EditEncounterCommand.MESSAGE_SUCCESS, 1, withEncounters.getName());
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidPersonIndex_failure() {
+        Index outOfBound = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDescription("Updated");
+        EditEncounterCommand command = new EditEncounterCommand(outOfBound, Index.fromOneBased(1), descriptor);
+        assertCommandFailure(command, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidEncounterIndex_failure() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDescription("Updated");
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(2), descriptor);
+
+        assertCommandFailure(command, model, EditEncounterCommand.MESSAGE_INVALID_ENCOUNTER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_preservesEncounterOrder() throws Exception {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person withEncounters = new PersonBuilder(original).withEncounters(OLDER_ENCOUNTER, NEWER_ENCOUNTER).build();
+        model.setPerson(original, withEncounters);
+
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDescription("Updated newest");
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        command.execute(model);
+
+        List<Encounter> result = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getEncounters();
+        assertEquals("Brief interaction", result.get(0).description);
+        assertEquals("Updated newest", result.get(1).description);
+    }
+
+    @Test
+    public void equals() {
+        EditEncounterDescriptor descriptor1 = new EditEncounterDescriptor();
+        descriptor1.setDescription("Desc 1");
+        EditEncounterDescriptor descriptor2 = new EditEncounterDescriptor();
+        descriptor2.setDescription("Desc 2");
+
+        EditEncounterCommand first = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor1);
+        EditEncounterCommand second = new EditEncounterCommand(INDEX_SECOND_PERSON, Index.fromOneBased(1), descriptor1);
+        EditEncounterCommand differentDescriptor =
+                new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor2);
+
+        assertTrue(first.equals(first));
+        assertTrue(first.equals(new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor1)));
+        assertFalse(first.equals(null));
+        assertFalse(first.equals(5));
+        assertFalse(first.equals(second));
+        assertFalse(first.equals(differentDescriptor));
+    }
+
+    @Test
+    public void toStringMethod() {
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDescription("Updated description");
+        EditEncounterCommand command = new EditEncounterCommand(INDEX_FIRST_PERSON, Index.fromOneBased(1), descriptor);
+
+        String expected = EditEncounterCommand.class.getCanonicalName()
+                + "{personIndex=" + INDEX_FIRST_PERSON
+                + ", encounterIndex=" + Index.fromOneBased(1)
+                + ", editEncounterDescriptor=" + descriptor + "}";
+        assertEquals(expected, command.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EditEncounterCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -66,6 +67,20 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_editEncounter() throws Exception {
+        EditEncounterCommand.EditEncounterDescriptor descriptor = new EditEncounterCommand.EditEncounterDescriptor();
+        descriptor.setDescription("Updated encounter");
+        EditEncounterCommand expectedCommand =
+                new EditEncounterCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON, descriptor);
+
+        EditEncounterCommand command = (EditEncounterCommand) parser.parseCommand(
+                EditEncounterCommand.COMMAND_WORD + " "
+                        + INDEX_FIRST_PERSON.getOneBased() + " "
+                        + INDEX_FIRST_PERSON.getOneBased() + " desc/Updated encounter");
+        assertEquals(expectedCommand, command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditEncounterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditEncounterCommandParserTest.java
@@ -1,0 +1,153 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OUTCOME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditEncounterCommand;
+import seedu.address.logic.commands.EditEncounterCommand.EditEncounterDescriptor;
+import seedu.address.model.person.Encounter;
+
+public class EditEncounterCommandParserTest {
+
+    private static final String VALID_PERSON_INDEX = "1";
+    private static final String VALID_ENCOUNTER_INDEX = "2";
+    private static final String VALID_DATE = "2026-03-26";
+    private static final String VALID_TIME = "18:30";
+    private static final String VALID_LOCATION = "Maxwell Road";
+    private static final String VALID_DESCRIPTION = "Met at coffee shop";
+    private static final String VALID_OUTCOME = "Agreed to cooperate";
+
+    private static final String DATE_DESC = " " + PREFIX_DATE + VALID_DATE;
+    private static final String TIME_DESC = " " + PREFIX_TIME + VALID_TIME;
+    private static final String LOCATION_DESC = " " + PREFIX_LOCATION + VALID_LOCATION;
+    private static final String DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_DESCRIPTION;
+    private static final String OUTCOME_DESC = " " + PREFIX_OUTCOME + VALID_OUTCOME;
+    private static final String OUTCOME_EMPTY_DESC = " " + PREFIX_OUTCOME;
+
+    private static final String INVALID_DATE_DESC = " " + PREFIX_DATE + "26-03-2026";
+    private static final String INVALID_TIME_DESC = " " + PREFIX_TIME + "25:00";
+    private static final String INVALID_LOCATION_BLANK = " " + PREFIX_LOCATION + " ";
+    private static final String INVALID_DESCRIPTION_BLANK = " " + PREFIX_DESCRIPTION + " ";
+
+    private final EditEncounterCommandParser parser = new EditEncounterCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDate(LocalDate.of(2026, 3, 26));
+        descriptor.setTime(LocalTime.of(18, 30));
+        descriptor.setLocation(VALID_LOCATION);
+        descriptor.setDescription(VALID_DESCRIPTION);
+        descriptor.setOutcome(Optional.of(VALID_OUTCOME));
+
+        EditEncounterCommand expectedCommand =
+                new EditEncounterCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, descriptor);
+
+        assertParseSuccess(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX
+                        + DATE_DESC + TIME_DESC + LOCATION_DESC + DESCRIPTION_DESC + OUTCOME_DESC,
+                expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsPresent_success() {
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setDescription(VALID_DESCRIPTION);
+
+        EditEncounterCommand expectedCommand =
+                new EditEncounterCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, descriptor);
+
+        assertParseSuccess(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + DESCRIPTION_DESC,
+                expectedCommand);
+    }
+
+    @Test
+    public void parse_clearOutcome_success() {
+        EditEncounterDescriptor descriptor = new EditEncounterDescriptor();
+        descriptor.setOutcome(Optional.empty());
+
+        EditEncounterCommand expectedCommand =
+                new EditEncounterCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, descriptor);
+
+        assertParseSuccess(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + OUTCOME_EMPTY_DESC,
+                expectedCommand);
+    }
+
+    @Test
+    public void parse_missingParts_failure() {
+        // missing encounter index
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+
+        // missing person index
+        assertParseFailure(parser,
+                VALID_ENCOUNTER_INDEX + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+
+        // no fields specified
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX,
+                EditEncounterCommand.MESSAGE_NOT_EDITED);
+    }
+
+    @Test
+    public void parse_invalidIndexes_failure() {
+        assertParseFailure(parser,
+                "0 1" + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "1 0" + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "a 1" + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                "1 b" + DESCRIPTION_DESC,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditEncounterCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidValues_failure() {
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + INVALID_DATE_DESC + DESCRIPTION_DESC,
+                "Invalid date. Use format YYYY-MM-DD.");
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + INVALID_TIME_DESC + DESCRIPTION_DESC,
+                "Invalid time. Use 24-hour format HH:mm.");
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + INVALID_LOCATION_BLANK + DESCRIPTION_DESC,
+                Encounter.MESSAGE_LOCATION_CONSTRAINTS);
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + INVALID_DESCRIPTION_BLANK,
+                Encounter.MESSAGE_DESCRIPTION_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_duplicatePrefixes_failure() {
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX + DATE_DESC + DATE_DESC + DESCRIPTION_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DATE));
+        assertParseFailure(parser,
+                VALID_PERSON_INDEX + " " + VALID_ENCOUNTER_INDEX
+                        + DESCRIPTION_DESC + DESCRIPTION_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_DESCRIPTION));
+    }
+}


### PR DESCRIPTION
Resolves #56

Add `edit` and `editencounter`  commands.

Usage examples:

Edit contact fields:
  `edit 1 p/91234567 r/high`
  `edit 2 note/Pretty decent looking`

Edit encounter fields:
  `editencounter 1 1 desc/Gave me drugs`
  `editencounter 1 2 d/2026-03-27 t/20:15 l/Tanjong Pagar`
  `editencounter 1 1 out/` (clears outcome)