### PR TITLE
Add specific symbols allowed for name field 

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces, and may include internal apostrophes ('),"
+                    + " slashes (/), or hyphens (-). It should not be blank.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}]+(?:[ '/-][\\p{Alnum}]+)*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}]+(?:[ '/-][\\p{Alnum}]+)*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}]+(?:[ '/-][\\p{Alnum}]+)*(?: )*";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,6 +29,9 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("-James")); // starts with special character
+        assertFalse(Name.isValidName("James-")); // ends with special character
+        assertFalse(Name.isValidName("O''Brien")); // repeated special character
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,6 +39,9 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Karthik S/O Selvam")); // slash-separated initials
+        assertTrue(Name.isValidName("Mike O'Brien")); // apostrophe in surname
+        assertTrue(Name.isValidName("James Weasley-Granger")); // hyphenated surname
     }
 
     @Test


### PR DESCRIPTION
fixes #202 

Allows names to have symbols like '/', ' ' ', '-' which can be used in names like "O'Brien", "Mike-John", "Karthik S/O Selvam". 
Doesn't allow special characters in the beginning or end of names, or double use ("Mike--John"). 9 LoC changed.