### PR TITLE
Add password support for delete command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -369,7 +369,7 @@ Optional, contact-level password protection. Each contact can be protected with 
 |---------|-------------|
 | **Scope** | Per-contact (individual contacts can be protected) |
 | **Type** | Optional (contacts don't require passwords) |
-| **Usage** | Add `pw/PASSWORD` to `add` or `edit` commands to protect; provide it with `view` to access |
+| **Usage** | Add `pw/PASSWORD` to `add` or `edit` commands to protect; provide current password for `view`, `delete`, `log`, and `remind` on protected contacts |
 | **Validation** | Alphanumeric characters and spaces only |
 
 ### Usage
@@ -387,9 +387,13 @@ edit 1 pw/              # Remove protection
 view 1 pw/password123   # Show full details if password correct
 view 1                  # Error: password required
 
+### Delete protected contact
+delete 1 pw/password123 # Delete succeeds if password is correct
+delete 1                # Error: password required (if protected)
+
 ### Behavior
 - **Without password**: Contact viewable normally
-- **With password**: `view` command requires correct password to display full details
+- **With password**: `view`, `delete`, `log`, and `remind` require the correct current password
 - **Plain text**: Passwords stored without encryption (not production-ready)
 
 ### Sequence Diagram
@@ -592,6 +596,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
     Use case resumes at step 2.
 
+* 3b. The target contact is password-protected and password is missing or incorrect.
+
+   * 3b1. CrimeWatch shows an error message.
+
+      Use case resumes at step 2.
+
 **Use case: Edit a person**
 
 **MSS**
@@ -747,6 +757,12 @@ Given below are manual tests for major functional paths and edge cases.
    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
    1. Test case: `delete 1`
       Expected: First contact is deleted from the list. Details of the deleted contact are shown in the status message. Timestamp in the status bar is updated.
+   1. Test case (password-protected contact): `delete 1 pw/hunter2`
+      Expected: Contact is deleted only when the supplied password is correct.
+   1. Test case (password-protected contact): `delete 1`
+      Expected: No person is deleted. Password-required error is shown.
+   1. Test case (unprotected contact): `delete 1 pw/hunter2`
+      Expected: No person is deleted. Error indicates `pw/` should be removed.
    1. Test case: `delete 0`
       Expected: No person is deleted. Error details are shown in the status message. Status bar remains the same.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -48,7 +48,7 @@ CrimeWatch supports 11 core features: **Add**, **Edit**, and **Delete** contacts
 | --- | --- | --- |
 | Add Contact | `add n/NAME p/PHONE e/EMAIL a/ADDRESS s/STAGE [al/ALIAS(,ALIAS...)] [note/NOTES] [r/RISK] [pw/PASSWORD] [t/TAG]...` | [1) Add Contact](#1-add-contact-add) |
 | Edit Contact | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/STAGE] [al/ALIAS(,ALIAS...)] [note/NOTES] [r/RISK] [pw/PASSWORD] [t/TAG]...` | [2) Edit Contact](#2-edit-contact-edit) |
-| Delete Contact | `delete INDEX` | [3) Delete Contact](#3-delete-contact-delete) |
+| Delete Contact | `delete INDEX [pw/PASSWORD]` | [3) Delete Contact](#3-delete-contact-delete) |
 | Log Encounter | `log INDEX d/DATE t/TIME l/LOCATION desc/DESCRIPTION [out/OUTCOME] [pw/PASSWORD]` | [4) Log Encounter](#4-log-encounter-log) |
 | Edit Encounter | `editencounter PERSON_INDEX ENCOUNTER_INDEX [d/DATE] [t/TIME] [l/LOCATION] [desc/DESCRIPTION] [out/OUTCOME]` | [5) Edit Encounter](#5-edit-encounter-editencounter) |
 | Set Reminder | `remind INDEX d/DATE t/TIME note/NOTE [pw/PASSWORD]` | [6) Set Reminder](#6-set-reminder-remind) |
@@ -214,13 +214,21 @@ Updates details of an existing contact without deleting and re-adding the profil
 Removes a contact permanently, including all associated encounters and reminders.
 
 **Format**
-`delete INDEX`
+`delete INDEX [pw/PASSWORD]`
 
-**Example**
-`delete 3`
+**Parameters**
+- `INDEX` (compulsory): target contact in current list
+- **`pw/PASSWORD` (optional):** if the contact is password-protected, supply the **current** password
+
+**Examples**
+- `delete 3`
+- `delete 3 pw/oldSecret` (when the contact is password-protected)
 
 **Validation**
 - INDEX must exist in the current list.
+- If the contact is password-protected, omitting `pw/` causes a password-required error.
+- If the contact is password-protected, wrong `pw/` causes an incorrect-password error.
+- If the contact is not password-protected, do not supply `pw/`.
 - Error: `The person index provided is invalid`
 
 **Success output**

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -86,7 +86,7 @@ public class DeleteCommand extends Command {
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
     return targetIndex.equals(otherDeleteCommand.targetIndex)
-        && Objects.equals(providedPassword, otherDeleteCommand.providedPassword);
+            && Objects.equals(providedPassword, otherDeleteCommand.providedPassword);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,8 +1,10 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 
 import java.util.List;
+import java.util.Objects;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -20,15 +22,30 @@ public class DeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: INDEX (must be a positive integer) [" + PREFIX_PASSWORD + "PASSWORD]\n"
+            + "If the contact is password-protected, " + PREFIX_PASSWORD + " must be the current password.\n"
+            + "Example: " + COMMAND_WORD + " 1\n"
+            + "Example (protected): " + COMMAND_WORD + " 1 " + PREFIX_PASSWORD + "hunter2";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+        public static final String MESSAGE_PASSWORD_REQUIRED_FOR_DELETE =
+            "This contact is password-protected. Include " + PREFIX_PASSWORD + "CURRENT_PASSWORD in your delete.";
+        public static final String MESSAGE_UNEXPECTED_PASSWORD_FOR_DELETE =
+            "This contact is not password-protected. Remove " + PREFIX_PASSWORD + ".";
 
     private final Index targetIndex;
+        private final String providedPassword;
 
     public DeleteCommand(Index targetIndex) {
+        this(targetIndex, null);
+        }
+
+        /**
+         * Creates a delete command for an index with an optional password.
+         */
+        public DeleteCommand(Index targetIndex, String providedPassword) {
         this.targetIndex = targetIndex;
+        this.providedPassword = providedPassword;
     }
 
     @Override
@@ -41,6 +58,17 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (personToDelete.hasPassword()) {
+            if (providedPassword == null) {
+                throw new CommandException(MESSAGE_PASSWORD_REQUIRED_FOR_DELETE);
+            }
+            if (!personToDelete.isPasswordMatch(providedPassword)) {
+                throw new CommandException(ViewCommand.MESSAGE_INCORRECT_PASSWORD);
+            }
+        } else if (providedPassword != null) {
+            throw new CommandException(MESSAGE_UNEXPECTED_PASSWORD_FOR_DELETE);
+        }
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
@@ -57,13 +85,15 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+    return targetIndex.equals(otherDeleteCommand.targetIndex)
+        && Objects.equals(providedPassword, otherDeleteCommand.providedPassword);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetIndex", targetIndex)
+            .add("hasProvidedPassword", providedPassword != null)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -28,22 +28,22 @@ public class DeleteCommand extends Command {
             + "Example (protected): " + COMMAND_WORD + " 1 " + PREFIX_PASSWORD + "hunter2";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
-        public static final String MESSAGE_PASSWORD_REQUIRED_FOR_DELETE =
+    public static final String MESSAGE_PASSWORD_REQUIRED_FOR_DELETE =
             "This contact is password-protected. Include " + PREFIX_PASSWORD + "CURRENT_PASSWORD in your delete.";
-        public static final String MESSAGE_UNEXPECTED_PASSWORD_FOR_DELETE =
+    public static final String MESSAGE_UNEXPECTED_PASSWORD_FOR_DELETE =
             "This contact is not password-protected. Remove " + PREFIX_PASSWORD + ".";
 
     private final Index targetIndex;
-        private final String providedPassword;
+    private final String providedPassword;
 
     public DeleteCommand(Index targetIndex) {
         this(targetIndex, null);
-        }
+    }
 
-        /**
-         * Creates a delete command for an index with an optional password.
-         */
-        public DeleteCommand(Index targetIndex, String providedPassword) {
+    /**
+     * Creates a delete command for an index with an optional password.
+     */
+    public DeleteCommand(Index targetIndex, String providedPassword) {
         this.targetIndex = targetIndex;
         this.providedPassword = providedPassword;
     }
@@ -85,7 +85,7 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-    return targetIndex.equals(otherDeleteCommand.targetIndex)
+        return targetIndex.equals(otherDeleteCommand.targetIndex)
             && Objects.equals(providedPassword, otherDeleteCommand.providedPassword);
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -18,8 +19,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_PASSWORD);
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_PASSWORD);
+
+            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            String password = null;
+            if (argMultimap.getValue(PREFIX_PASSWORD).isPresent()) {
+                password = ParserUtil.parsePassword(argMultimap.getValue(PREFIX_PASSWORD).get()).toString();
+            }
+            return new DeleteCommand(index, password);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -80,9 +81,52 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_protectedContactWithoutPassword_throwsCommandException() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person passwordProtected = new PersonBuilder(original).withPassword("secret").build();
+        model.setPerson(original, passwordProtected);
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_PASSWORD_REQUIRED_FOR_DELETE);
+    }
+
+    @Test
+    public void execute_protectedContactWrongPassword_throwsCommandException() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person passwordProtected = new PersonBuilder(original).withPassword("secret").build();
+        model.setPerson(original, passwordProtected);
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, "wrong");
+        assertCommandFailure(deleteCommand, model, ViewCommand.MESSAGE_INCORRECT_PASSWORD);
+    }
+
+    @Test
+    public void execute_protectedContactCorrectPassword_success() {
+        Person original = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person passwordProtected = new PersonBuilder(original).withPassword("secret").build();
+        model.setPerson(original, passwordProtected);
+
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, "secret");
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(passwordProtected));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(passwordProtected);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_unprotectedContactWithPassword_throwsCommandException() {
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, "secret");
+        assertCommandFailure(deleteCommand, model, DeleteCommand.MESSAGE_UNEXPECTED_PASSWORD_FOR_DELETE);
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteFirstWithPasswordCommand = new DeleteCommand(INDEX_FIRST_PERSON, "secret");
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
@@ -90,6 +134,9 @@ public class DeleteCommandTest {
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // same index but different password -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteFirstWithPasswordCommand));
 
         // different types -> returns false
         assertFalse(deleteFirstCommand.equals(1));
@@ -105,7 +152,8 @@ public class DeleteCommandTest {
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
         DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        String expected = DeleteCommand.class.getCanonicalName()
+                + "{targetIndex=" + targetIndex + ", hasProvidedPassword=false}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -57,6 +57,10 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+
+        DeleteCommand protectedCommand = (DeleteCommand) parser.parseCommand(
+            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " pw/secret");
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON, "secret"), protectedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -23,10 +23,13 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        assertParseSuccess(parser, "1 pw/secret", new DeleteCommand(INDEX_FIRST_PERSON, "secret"));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1 pw/one pw/two",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
## Summary
This PR extends per-contact password protection to the `delete` command. Fixes #210 

Previously, protected contacts required `pw/` for `view`, `edit`, `log`, and `remind`, but not for `delete`.  
Now, deleting a protected contact also requires the correct current password.

## What Changed
- Added optional `pw/PASSWORD` parsing to `delete`
- Updated `DeleteCommand` execution logic:
  - Protected contact:
    - missing `pw/` -> reject with password-required error
    - wrong `pw/` -> reject with incorrect-password error
    - correct `pw/` -> delete succeeds
  - Unprotected contact:
    - provided `pw/` -> reject with unexpected-password error
- Updated delete usage/help text to include `pw/` behavior
- Updated docs in User Guide and Developer Guide to reflect the new delete flow
- Added/updated tests for command/parser behavior and parser wiring

## Files Updated
- DeleteCommand.java
- DeleteCommandParser.java
- DeleteCommandTest.java
- DeleteCommandParserTest.java
- AddressBookParserTest.java
- UserGuide.md
- DeveloperGuide.md

## Test Coverage
Ran focused tests successfully:
- `seedu.address.logic.commands.DeleteCommandTest`
- `seedu.address.logic.parser.DeleteCommandParserTest`
- `seedu.address.logic.parser.AddressBookParserTest`

Command used:
`.gradlew.bat test --tests "seedu.address.logic.commands.DeleteCommandTest" --tests "seedu.address.logic.parser.DeleteCommandParserTest" --tests "seedu.address.logic.parser.AddressBookParserTest"`

## Notes
- This PR aligns `delete` with existing password-protected command behavior.
- Password handling remains unchanged from existing implementation (plain-text storage, current password match).